### PR TITLE
Use `fix-846` and implement hyper functions for abstracting over sensitivity

### DIFF
--- a/pkg/addr/host.go
+++ b/pkg/addr/host.go
@@ -36,6 +36,7 @@ import (
 	"github.com/scionproto/scion/pkg/private/serrors"
 	//@ . "github.com/scionproto/scion/verification/utils/definitions"
 	//@ sl "github.com/scionproto/scion/verification/utils/slices"
+	//@ "github.com/scionproto/scion/verification/utils/sif"
 )
 
 type HostAddrType uint8
@@ -224,6 +225,7 @@ func (h HostIPv4) IP() (res net.IP) {
 	//@ 	h.GetByte(i) == h[i]
 	//@ unfold acc(h.Mem(), R13/2)
 	//@ unfold acc(sl.Bytes(h, 0, len(h)), R13/2)
+	//@ assert reveal sif.IsLowByteSlice(h)
 	return net.IP(h).To4( /*@ false @*/ )
 }
 
@@ -507,8 +509,7 @@ func HostFromRaw(b []byte, htype HostAddrType) (res HostAddr, err error) {
 
 // @ requires acc(ip)
 // @ requires len(ip) == HostLenIPv4 || len(ip) == HostLenIPv6
-// @ requires low(len(ip)) && forall i int :: { &ip[i] } 0 <= i && i < len(ip) &&
-// @ 	low(i) ==> low(ip[i])
+// @ requires sif.IsLowByteSlice(ip)
 // @ ensures  res.Mem()
 // @ decreases
 func HostFromIP(ip net.IP) (res HostAddr) {

--- a/pkg/addr/host_spec.gobra
+++ b/pkg/addr/host_spec.gobra
@@ -64,11 +64,10 @@ trusted
 requires p > 0
 requires acc(h.Mem(), p) && h.IsLow()
 ensures  acc(h.Mem(), p)
-// NOTE[henri]: If it wasn't for encoding leading to insufficient permissions,
-// we could implement this postcondition as:
+// NOTE[henri]: Should we introduce a hyper function for this specific case?
+// Or leave as is? Alternatively, once Gobra issue #955 is resolved, we could
+// implement this postcondition as:
 // ensures  unfolding acc(h.Mem(), p) in sif.IsLowBytes(h, 0, len(h))
-// TODO: alternatively, introduce IsLowSlice for this situation in particular.
-// Do I want this? Or just keep it like this for these cases?
 ensures  low(len(h)) && forall i int :: { h.GetByte(i) } 0 <= i && i < len(h) &&
 	low(i) ==> low(h.GetByte(i))
 decreases

--- a/pkg/addr/host_spec.gobra
+++ b/pkg/addr/host_spec.gobra
@@ -21,6 +21,7 @@ import (
 
 	"github.com/scionproto/scion/verification/utils/errors"
 	"github.com/scionproto/scion/verification/utils/slices"
+	"github.com/scionproto/scion/verification/utils/sif"
 )
 
 pred (h HostNone) Mem() { len(h) == HostLenNone }
@@ -63,6 +64,11 @@ trusted
 requires p > 0
 requires acc(h.Mem(), p) && h.IsLow()
 ensures  acc(h.Mem(), p)
+// NOTE[henri]: If it wasn't for encoding leading to insufficient permissions,
+// we could implement this postcondition as:
+// ensures  unfolding acc(h.Mem(), p) in sif.IsLowBytes(h, 0, len(h))
+// TODO: alternatively, introduce IsLowSlice for this situation in particular.
+// Do I want this? Or just keep it like this for these cases?
 ensures  low(len(h)) && forall i int :: { h.GetByte(i) } 0 <= i && i < len(h) &&
 	low(i) ==> low(h.GetByte(i))
 decreases

--- a/pkg/addr/isdas.go
+++ b/pkg/addr/isdas.go
@@ -88,6 +88,7 @@ func ParseAS(_as string) (retAs AS, retErr error) {
 // @ decreases
 func parseAS(_as string, sep string) (retAs AS, retErr error) {
 	parts := strings.Split(_as, sep)
+	//@ reveal sif.IsLowStringSlice(parts)
 	if len(parts) == 1 {
 		// Must be a BGP AS, parse as 32-bit decimal number
 		return asParseBGP(_as)
@@ -99,12 +100,13 @@ func parseAS(_as string, sep string) (retAs AS, retErr error) {
 	var parsed AS
 	//@ invariant 0 <= i && i <= asParts
 	//@ invariant acc(parts)
-	//@ invariant forall i int :: { parts[i] } 0 <= i && i < len(parts) && 
-	//@ 	low(i) ==> low(parts[i])
+	// TODO: this isn't a byte slice right
+	//@ invariant sif.IsLowStringSlice(parts)
 	//@ invariant low(i) && low(_as) && low(parsed)
 	//@ decreases asParts - i
 	for i := 0; i < asParts; i++ {
 		parsed <<= asPartBits
+		//@ reveal sif.IsLowStringSlice(parts)
 		v, err := strconv.ParseUint(parts[i], asPartBase, asPartBits)
 		if err != nil {
 			return 0, serrors.WrapStr("parsing AS part", err, "index", i, "value", _as)
@@ -167,8 +169,7 @@ func (_as AS) MarshalText() ([]byte, error) {
 }
 
 // @ requires  forall i int :: { &text[i] } 0 <= i && i < len(text) ==> acc(&text[i])
-// @ requires  low(len(text)) && forall i int :: { text[i] } 0 <= i && i < len(text) &&
-// @ 	low(i) ==> low(text[i])
+// @ requires  sif.IsLowByteSlice(text)
 // @ preserves acc(_as)
 // @ ensures   forall i int :: { &text[i] } 0 <= i && i < len(text) ==> acc(&text[i])
 // @ decreases
@@ -222,6 +223,7 @@ func IAFrom(isd ISD, _as AS) (ia IA, err error) {
 // @ decreases
 func ParseIA(ia string) (retIA IA, retErr error) {
 	parts := strings.Split(ia, "-")
+	//@ reveal sif.IsLowStringSlice(parts)
 	if len(parts) != 2 {
 		return 0, serrors.New("invalid ISD-AS", "value", ia)
 	}
@@ -254,8 +256,7 @@ func (ia IA) MarshalText() ([]byte, error) {
 }
 
 // @ requires  forall i int :: { &b[i] } 0 <= i && i < len(b) ==> acc(&b[i])
-// @ requires  low(len(b)) && forall i int :: { b[i] } 0 <= i && i < len(b) &&
-// @ 	low(i) ==> low(b[i])
+// @ requires  sif.IsLowByteSlice(b)
 // @ preserves acc(ia)
 // @ ensures   forall i int :: { &b[i] } 0 <= i && i < len(b) ==> acc(&b[i])
 // @ decreases

--- a/pkg/addr/isdas.go
+++ b/pkg/addr/isdas.go
@@ -100,7 +100,6 @@ func parseAS(_as string, sep string) (retAs AS, retErr error) {
 	var parsed AS
 	//@ invariant 0 <= i && i <= asParts
 	//@ invariant acc(parts)
-	// TODO: this isn't a byte slice right
 	//@ invariant sif.IsLowStringSlice(parts)
 	//@ invariant low(i) && low(_as) && low(parsed)
 	//@ decreases asParts - i

--- a/private/topology/linktype.go
+++ b/private/topology/linktype.go
@@ -68,8 +68,8 @@ func LinkTypeFromString(s string) (res LinkType) {
 	var l /*@@@*/ LinkType
 	tmp := []byte(s)
 	// TODO: Once Gobra issue #831 is resolved, remove this assumption.
-	//@ assume forall i int :: { &tmp[i] } 0 <= i && i < len(tmp) ==> low(tmp[i])
-	//@ fold sl.Bytes(tmp, 0, len(tmp))
+	//@ assume sif.IsLowByteSlice(tmp)
+	//@ sif.FoldLowByteSlice(tmp)
 	if err := l.UnmarshalText(tmp); err != nil {
 		return Unset
 	}
@@ -79,9 +79,7 @@ func LinkTypeFromString(s string) (res LinkType) {
 // @ requires low(l)
 // @ ensures (l == Core || l == Parent || l == Child || l == Peer) == (err == nil)
 // @ ensures err == nil ==> sl.Bytes(res, 0, len(res))
-// @ ensures err == nil ==> low(len(res)) && 
-// @ 	forall i int :: { sl.GetByte(res, 0, len(res), i) } 0 <= i && i < len(res) ==>
-// @ 	low(sl.GetByte(res, 0, len(res), i))
+// @ ensures err == nil ==> sif.IsLowBytes(res, 0, len(res))
 // @ ensures err != nil ==> err.ErrorMem()
 // @ ensures low(err != nil)
 // @ decreases
@@ -90,26 +88,26 @@ func (l LinkType) MarshalText() (res []byte, err error) {
 	case Core:
 		tmp := []byte("core")
 		// TODO: Once Gobra issue #831 is resolved, remove this assumption.
-		//@ assume forall i int :: { tmp[i] } 0 <= i && i < len(tmp) ==> low(tmp[i])
-		//@ fold sl.Bytes(tmp, 0, len(tmp))
+		//@ assume sif.IsLowByteSlice(tmp)
+		//@ sif.FoldLowByteSlice(tmp)
 		return tmp, nil
 	case Parent:
 		tmp := []byte("parent")
 		// TODO: Once Gobra issue #831 is resolved, remove this assumption.
-		//@ assume forall i int :: { tmp[i] } 0 <= i && i < len(tmp) ==> low(tmp[i])
-		//@ fold sl.Bytes(tmp, 0, len(tmp))
+		//@ assume sif.IsLowByteSlice(tmp)
+		//@ sif.FoldLowByteSlice(tmp)
 		return tmp, nil
 	case Child:
 		tmp := []byte("child")
 		// TODO: Once Gobra issue #831 is resolved, remove this assumption.
-		//@ assume forall i int :: { tmp[i] } 0 <= i && i < len(tmp) ==> low(tmp[i])
-		//@ fold sl.Bytes(tmp, 0, len(tmp))
+		//@ assume sif.IsLowByteSlice(tmp)
+		//@ sif.FoldLowByteSlice(tmp)
 		return tmp, nil
 	case Peer:
 		tmp := []byte("peer")
 		// TODO: Once Gobra issue #831 is resolved, remove this assumption.
-		//@ assume forall i int :: { tmp[i] } 0 <= i && i < len(tmp) ==> low(tmp[i])
-		//@ fold sl.Bytes(tmp, 0, len(tmp))
+		//@ assume sif.IsLowByteSlice(tmp)
+		//@ sif.FoldLowByteSlice(tmp)
 		return tmp, nil
 	default:
 		return nil, serrors.New("invalid link type")
@@ -117,9 +115,7 @@ func (l LinkType) MarshalText() (res []byte, err error) {
 }
 
 // @ requires acc(sl.Bytes(data, 0, len(data)), R15)
-// @ requires low(len(data)) && 
-// @ 	forall i int :: { sl.GetByte(data, 0, len(data), i) } 0 <= i && i < len(data) ==>
-// @ 	low(sl.GetByte(data, 0, len(data), i))
+// @ requires sif.IsLowBytes(data, 0, len(data))
 // @ preserves acc(l)
 // @ ensures acc(sl.Bytes(data, 0, len(data)), R15)
 // @ ensures err != nil ==> err.ErrorMem()
@@ -127,11 +123,8 @@ func (l LinkType) MarshalText() (res []byte, err error) {
 // @ ensures low(err != nil)
 // @ decreases
 func (l *LinkType) UnmarshalText(data []byte) (err error) {
-	//@ BeforeUnfold:
-	//@ unfold acc(sl.Bytes(data, 0, len(data)), R15)
+	//@ sif.UnfoldLowBytes(data, R15)
 	//@ ghost defer fold acc(sl.Bytes(data, 0, len(data)), R15)
-	//@ assert forall i int :: { sl.GetByte(data, 0, len(data), i) } 0 <= i && i < len(data) ==>
-	//@ 	old[BeforeUnfold](sl.GetByte(data, 0, len(data), i)) == data[i]
 	//@ sif.LowSliceImpliesLowString(data, R15)
 	switch strings.ToLower(string(data)) {
 	case "core":

--- a/private/underlay/conn/conn.go
+++ b/private/underlay/conn/conn.go
@@ -34,6 +34,7 @@ import (
 	"github.com/scionproto/scion/private/underlay/sockctrl"
 	//@ . "github.com/scionproto/scion/verification/utils/definitions"
 	//@ sl "github.com/scionproto/scion/verification/utils/slices"
+	//@ "github.com/scionproto/scion/verification/utils/sif"
 )
 
 // Messages is a list of ipX.Messages. It is necessary to hide the type alias
@@ -141,6 +142,7 @@ func New(listen, remote *net.UDPAddr, cfg *Config) (res Conn, e error) {
 	// @ unfold acc(sl.Bytes(a.IP, 0, len(a.IP)), R15)
 	// @ assert forall i int :: { &a.IP[i] } 0 <= i && i < len(a.IP) ==>
 	// @ 	a.GetIPByte(i) == a.IP[i]
+	// @ assert reveal sif.IsLowByteSlice(a.IP)
 	if a.IP.To4( /*@ false @*/ ) != nil {
 		return newConnUDPIPv4(listen, remote, cfg)
 	}

--- a/private/underlay/conn/conn_spec.gobra
+++ b/private/underlay/conn/conn_spec.gobra
@@ -165,21 +165,26 @@ pure func (c *Config) Deref() Config {
 	return unfolding c.Mem() in *c
 }
 
-// TODO: Once Gobra issue #846 is resolved, actually implement `IsLow`.
 ghost
-trusted
+opaque
+hyper
 requires c.Mem()
 decreases
-pure func (c *Config) IsLow() bool
+pure func (c *Config) IsLow() bool {
+	return low(c.Deref())
+}
 
-// "Reveal the body" of `c.IsLow` (necessary bc. we can't implement `c.IsLow` yet).
-// TODO: Once Gobra issue #846 is resolved, implement this.
+// "Reveal the body" of `c.IsLow` (remnant from when we couldn't implement it yet).
 ghost
-trusted
-requires acc(c.Mem(), R1) && c.IsLow()
+// NOTE[henri]: Due to Gobra issue #955, we have to split the precondition 
+// across two `requires`.
+requires acc(c.Mem(), R1)
+requires c.IsLow()
 ensures  acc(c.Mem(), R1) && low(c.Deref())
 decreases
-func (c *Config) RevealIsLow()
+func (c *Config) RevealIsLow() {
+	reveal c.IsLow()
+}
 
 /** Lift methods in *connUDPBase to *connUDPIPv4 **/
 *connUDPIPv4 implements Conn

--- a/private/underlay/sockctrl/sockopt.go
+++ b/private/underlay/sockctrl/sockopt.go
@@ -25,9 +25,12 @@ import (
 // overspecify this function to recover low(inputs) ==> low(outputs).
 // @ trusted
 // @ requires  low(level) && low(opt)
-// @ preserves c.Mem() && c.IsLow()
+// NOTE[henri]: Due to Gobra issue #955, we have to put the call to `IsLow`
+// in its own `preserves`.
+// @ preserves c.Mem()
+// @ preserves c.IsLow()
 // @ ensures   e != nil ==> e.ErrorMem()
-// @ ensures   low(r) && low(e)
+// @ ensures   low(r) && low(e != nil)
 // @ decreases _
 func GetsockoptInt(c *net.UDPConn, level, opt int) (r int, e error) {
 	var val int

--- a/verification/dependencies/encoding/encoding.gobra
+++ b/verification/dependencies/encoding/encoding.gobra
@@ -16,12 +16,13 @@
 
 package encoding
 
+import "github.com/scionproto/scion/verification/utils/sif"
+
 type TextUnmarshaler interface {
 	pred Mem()
 	
 	requires  acc(text)
-	requires  low(len(text)) && forall i int :: { text[i] } 0 <= i && i < len(text) &&
-		low(i) ==> low(text[i])
+	requires  sif.IsLowByteSlice(text)
 	preserves Mem()
 	ensures   acc(text)
 	decreases

--- a/verification/dependencies/net/ip.gobra
+++ b/verification/dependencies/net/ip.gobra
@@ -11,6 +11,7 @@ package net
 
 import . "github.com/scionproto/scion/verification/utils/definitions"
 import sl "github.com/scionproto/scion/verification/utils/slices"
+import "github.com/scionproto/scion/verification/utils/sif"
 
 // IP address lengths (bytes).
 const (
@@ -63,8 +64,8 @@ func (ip IP) IsGlobalUnicast() bool
 // To4 converts the IPv4 address ip to a 4-byte representation.
 requires   wildcard ==> forall i int :: { &ip[i] } 0 <= i && i < len(ip) ==> acc(&ip[i], _)
 requires  !wildcard ==> forall i int :: { &ip[i] } 0 <= i && i < len(ip) ==> acc(&ip[i], R20)
-requires  low(len(ip)) && forall i int :: { &ip[i] } 0 <= i && i < len(ip) &&
-	low(i) ==> low(ip[i])
+// TODO: dunno if this is possible considering IP is type alias
+requires  sif.IsLowByteSlice(ip)
 ensures    wildcard ==> forall i int :: { &ip[i] } 0 <= i && i < len(ip) ==> acc(&ip[i], _)
 ensures   !wildcard ==> forall i int :: { &ip[i] } 0 <= i && i < len(ip) ==> acc(&ip[i], R20)
 ensures   res != nil ==> len(res) == IPv4len
@@ -81,6 +82,7 @@ ensures   len(ip) != IPv4len && len(ip) != IPv6len ==> res == nil
 ensures   low(res != nil)
 decreases
 func (ip IP) To4(ghost wildcard bool) (res IP) {
+	reveal sif.IsLowByteSlice(ip)
 	if len(ip) == IPv4len {
 		return ip
 	}
@@ -161,7 +163,6 @@ pure func (ip IP) Equal(x IP) bool
 // ParseIP parses s as an IP address, returning the result.
 ensures forall i int :: {&res[i]} 0 <= i && i < len(res) ==> acc(&res[i])
 ensures res != nil ==> len(res) == IPv4len || len(res) == IPv6len
-ensures low(s) ==> low(res == nil) && low(len(res)) && 
-	forall i int :: { &res[i] } 0 <= i && i < len(res) && low(i) ==> low(res[i])
+ensures low(s) ==> low(res == nil) && sif.IsLowByteSlice(res)
 decreases _
 func ParseIP(s string) (res IP)

--- a/verification/dependencies/net/ip.gobra
+++ b/verification/dependencies/net/ip.gobra
@@ -64,7 +64,6 @@ func (ip IP) IsGlobalUnicast() bool
 // To4 converts the IPv4 address ip to a 4-byte representation.
 requires   wildcard ==> forall i int :: { &ip[i] } 0 <= i && i < len(ip) ==> acc(&ip[i], _)
 requires  !wildcard ==> forall i int :: { &ip[i] } 0 <= i && i < len(ip) ==> acc(&ip[i], R20)
-// TODO: dunno if this is possible considering IP is type alias
 requires  sif.IsLowByteSlice(ip)
 ensures    wildcard ==> forall i int :: { &ip[i] } 0 <= i && i < len(ip) ==> acc(&ip[i], _)
 ensures   !wildcard ==> forall i int :: { &ip[i] } 0 <= i && i < len(ip) ==> acc(&ip[i], R20)

--- a/verification/dependencies/net/udpsock.gobra
+++ b/verification/dependencies/net/udpsock.gobra
@@ -40,6 +40,7 @@ pure func (a *UDPAddr) GetIPByte(i int) byte {
 }
 
 // TODO: Once Gobra issue #846 is resolved, actually implement `IsLow`.
+// TODO: Once Gobra issue #955 and/or #963 are resolved, implement `IsLow`.
 // - Here, `IsLow` will need to cover all fields (of `UDPAddr`), since we use 
 //   this information in `DialUDP` and `ListenUDP` to imply that all fields of 
 //   the resulting `UDPConn` object are low. 
@@ -56,6 +57,7 @@ trusted
 requires acc(a.Mem(), R15) && a.IsLow()
 ensures  acc(a.Mem(), R15)
 ensures  low(len(a.GetIP()))
+// TODO: Once Gobra issue #963 is resolved, introduce `IsLowIP` function.
 ensures  forall i int :: { a.GetIPByte(i) } 0 <= i && i < len(a.GetIP()) ==>
 	low(i) ==> low(a.GetIPByte(i))
 decreases
@@ -90,11 +92,12 @@ pred (u *UDPConn) Mem() {
 	acc(u)
 }
 
-// TODO: Once Gobra issue #846 is resolved, actually implement `IsLow`.
-// - Here, `IsLow` will need to cover all fields (of `UDPConn`), since we use 
-//   this information in private/underlay/sockctrl/sockopt.go, `GetsockoptInt`.
+// As we don't model the fields of `UDPConn`, `IsLow` is kept abstract.
+// The only way to create an instance of `*UDPConn` is by calling `ListenUDP`
+// or `DialUDP`. We require their input to be low; in return, we ensure that
+// `IsLow` holds for the returned instance.
 ghost
-trusted
+hyper
 requires c.Mem()
 decreases
 pure func (c *UDPConn) IsLow() bool
@@ -157,30 +160,46 @@ func (c *UDPConn) Close() (err error)
 
 requires acc(laddr.Mem(), _)
 requires low(network) && laddr.IsLow()
-ensures  err == nil ==> conn.Mem() && conn.IsLow()
-ensures  err != nil ==> err.ErrorMem()
+// NOTE[henri]: While Gobra issue #955, persists, `low(err != nil)` needs to
+// come before the other sensitivity annotations.
 ensures  low(err != nil)
+// NOTE[henri]: Due to Gobra issue #955, we have to put the call to `IsLow`
+// in its own `ensures`.
+ensures  err == nil ==> conn.Mem()
+ensures  err == nil ==> conn.IsLow()
+ensures  err != nil ==> err.ErrorMem()
 decreases _
 func ListenUDP(network string, laddr *UDPAddr) (conn *UDPConn, err error)
 
 requires acc(laddr.Mem(), _)
 requires acc(raddr.Mem(), _)
 requires low(network) && laddr.IsLow() && raddr.IsLow()
-ensures  err == nil ==> conn.Mem() && conn.IsLow()
-ensures  err != nil ==> err.ErrorMem()
+// NOTE[henri]: While Gobra issue #955, persists, `low(err != nil)` needs to
+// come before the other sensitivity annotations.
 ensures  low(err != nil)
+// NOTE[henri]: Due to Gobra issue #955, we have to put the call to `IsLow`
+// in its own `ensures`.
+ensures  err == nil ==> conn.Mem()
+ensures  err == nil ==> conn.IsLow()
+ensures  err != nil ==> err.ErrorMem()
 decreases _
 func DialUDP(network string, laddr, raddr *UDPAddr) (conn *UDPConn, err error)
 
 requires  low(bytes)
-preserves c.Mem() && c.IsLow()
+// NOTE[henri]: Due to Gobra issue #955, we have to put the call to `IsLow`
+// in its own `preserves`.
+preserves c.Mem()
+preserves c.IsLow()
 ensures   err != nil ==> err.ErrorMem()
 ensures   low(err != nil)
 decreases _
 func (c *UDPConn) SetWriteBuffer(bytes int) (err error)
 
 requires  low(bytes)
-preserves c.Mem() && c.IsLow()
+// NOTE[henri]: Due to Gobra issue #955, we have to put the call to `IsLow`
+// in its own `preserves`.
+preserves c.Mem()
+preserves c.IsLow()
 ensures   low(err != nil)
 ensures   err != nil ==> err.ErrorMem()
 decreases _

--- a/verification/dependencies/strings/strings.gobra
+++ b/verification/dependencies/strings/strings.gobra
@@ -9,6 +9,8 @@
 
 package strings
 
+import "github.com/scionproto/scion/verification/utils/sif"
+
 // Count counts the number of non-overlapping instances of substr in s.
 // If substr is an empty string, Count returns 1 + the number of Unicode code points in s.
 func Count(s, substr string) int
@@ -66,9 +68,8 @@ func SplitAfterN(s, sep string, n int) (res []string)
 
 // Split slices s into all substrings separated by sep and returns a slice of
 // the substrings between those separators.
-ensures forall i int :: { &res[i] } 0 <= i && i < len(res) ==> 
-	acc(&res[i]) && ((low(s) && low(sep)) ==> low(i) ==> low(res[i]))
-ensures (low(s) && low(sep)) ==> low(len(res))
+ensures forall i int :: { &res[i] } 0 <= i && i < len(res) ==> acc(&res[i])
+ensures low(s) && low(sep) ==> sif.IsLowStringSlice(res)
 decreases _
 func Split(s, sep string) (res []string) //{ return genSplit(s, sep, 0, -1) }
 

--- a/verification/utils/sif/assumptions.gobra
+++ b/verification/utils/sif/assumptions.gobra
@@ -5,7 +5,7 @@ package sif
 // TODO: Once Gobra issue #832 is resolved, introduce body and prove this.
 ghost
 requires p > 0 && acc(b, p)
-requires low(len(b)) && forall i int :: { &b[i] } 0 <= i && i < len(b) ==> low(b[i])
+requires IsLowByteSlice(b)
 ensures acc(b, p) && low(string(b))
 decreases
 func LowSliceImpliesLowString(b []byte, p perm)

--- a/verification/utils/sif/utils.gobra
+++ b/verification/utils/sif/utils.gobra
@@ -17,6 +17,16 @@ pure func IsLowByteSlice(s []byte) bool {
 ghost
 opaque
 hyper
+requires acc(s)
+decreases
+pure func IsLowStringSlice(s []string) bool {
+    return low(len(s)) && forall i int :: { &s[i] } 0 <= i && i < len(s) &&
+        low(i) ==> low(s[i])
+}
+
+ghost
+opaque
+hyper
 requires sl.Bytes(s, start, end)
 decreases
 pure func IsLowBytes(s []byte, start, end int) bool {

--- a/verification/utils/sif/utils.gobra
+++ b/verification/utils/sif/utils.gobra
@@ -36,7 +36,7 @@ pure func IsLowBytes(s []byte, start, end int) bool {
 }
 
 // NOTE[henri]: Due to Gobra issue #955, we have to split the pre- and 
-// postcondition across two lines (resp.).
+// postcondition across two `requires`/`ensures` (resp.).
 requires acc(s)
 requires IsLowByteSlice(s)
 ensures  sl.Bytes(s, 0, len(s))

--- a/verification/utils/sif/utils.gobra
+++ b/verification/utils/sif/utils.gobra
@@ -31,7 +31,8 @@ requires sl.Bytes(s, start, end)
 decreases
 pure func IsLowBytes(s []byte, start, end int) bool {
     return low(len(s)) &&
-        forall i int :: { low(sl.GetByte(s, start, end, i)) } start <= i && i < end &&
+        // TODO: Once Gobra issue #964 is resolved, specify trigger.
+        forall i int :: start <= i && i < end &&
             low(i) ==> low(sl.GetByte(s, start, end, i))
 }
 
@@ -45,7 +46,7 @@ decreases
 func FoldLowByteSlice(s []byte) {
     reveal IsLowByteSlice(s)
     fold acc(sl.Bytes(s, 0, len(s)), 1/2)
-    assert forall i int :: { sl.GetByte(s, 0, len(s), i) }{ &s[i] } 0 <= i && i < len(s) ==>
+    assert forall i int :: { &s[i] } 0 <= i && i < len(s) ==>
         sl.GetByte(s, 0, len(s), i) == s[i]
     fold acc(sl.Bytes(s, 0, len(s)), 1/2)
     assert reveal IsLowBytes(s, 0, len(s))
@@ -61,9 +62,10 @@ decreases
 func UnfoldLowBytes(s []byte, ghost p perm) {
     reveal IsLowBytes(s, 0, len(s))
     unfold acc(sl.Bytes(s, 0, len(s)), p/2)
-    assert forall i int :: { low(sl.GetByte(s, 0, len(s), i)) } 0 <= i && i < len(s) &&
+    // TODO: Once Gobra issue #964 is resolved, specify trigger.
+    assert forall i int :: 0 <= i && i < len(s) &&
         low(i) ==> low(sl.GetByte(s, 0, len(s), i))
-    assert forall i int :: { sl.GetByte(s, 0, len(s), i) }{ &s[i] } 0 <= i && i < len(s) ==>
+    assert forall i int :: { &s[i] } 0 <= i && i < len(s) ==>
         sl.GetByte(s, 0, len(s), i) == s[i]
     unfold acc(sl.Bytes(s, 0, len(s)), p/2)
     assert reveal IsLowByteSlice(s)

--- a/verification/utils/sif/utils.gobra
+++ b/verification/utils/sif/utils.gobra
@@ -1,0 +1,62 @@
+// +gobra
+
+package sif
+
+import sl "github.com/scionproto/scion/verification/utils/slices"
+
+// TODO: Add `&& low(i) ==>` once the commits which add this to the other 
+// packages have been merged.
+
+ghost
+opaque
+hyper
+requires acc(s)
+decreases
+pure func IsLowByteSlice(s []byte) bool {
+    return low(len(s)) && forall i int :: { &s[i] } 0 <= i && i < len(s) ==> low(s[i])
+}
+
+ghost
+opaque
+hyper
+requires sl.Bytes(s, start, end)
+decreases
+pure func IsLowBytes(s []byte, start, end int) bool {
+    return low(len(s)) &&
+        forall i int :: { low(sl.GetByte(s, start, end, i)) } start <= i && i < end ==>
+            low(sl.GetByte(s, start, end, i))
+}
+
+// NOTE[henri]: Due to Gobra issue #955, we have to split the pre- and 
+// postcondition across two lines (resp.).
+requires acc(s)
+requires IsLowByteSlice(s)
+ensures  sl.Bytes(s, 0, len(s))
+ensures  IsLowBytes(s, 0, len(s))
+decreases
+func FoldLowByteSlice(s []byte) {
+    reveal IsLowByteSlice(s)
+    fold acc(sl.Bytes(s, 0, len(s)), 1/2)
+    assert forall i int :: { sl.GetByte(s, 0, len(s), i) }{ &s[i] } 0 <= i && i < len(s) ==> 
+        sl.GetByte(s, 0, len(s), i) == s[i]
+    fold acc(sl.Bytes(s, 0, len(s)), 1/2)
+    assert reveal IsLowBytes(s, 0, len(s))
+}
+
+// NOTE[henri]: Due to Gobra issue #955, we have to split the pre- and 
+// postcondition across two lines (resp.).
+requires p > 0 && acc(sl.Bytes(s, 0, len(s)), p)
+requires IsLowBytes(s, 0, len(s))
+ensures  acc(s, p)
+ensures  IsLowByteSlice(s)
+decreases
+func UnfoldLowBytes(s []byte, ghost p perm) {
+    reveal IsLowBytes(s, 0, len(s))
+    unfold acc(sl.Bytes(s, 0, len(s)), p/2)
+    assert forall i int :: { low(sl.GetByte(s, 0, len(s), i)) } 0 <= i && i < len(s) ==>
+        low(sl.GetByte(s, 0, len(s), i))
+    assert forall i int :: { sl.GetByte(s, 0, len(s), i) }{ &s[i] } 0 <= i && i < len(s) ==> 
+        sl.GetByte(s, 0, len(s), i) == s[i]
+    unfold acc(sl.Bytes(s, 0, len(s)), p/2)
+    assert reveal IsLowByteSlice(s)
+}


### PR DESCRIPTION
At least at the moment, the `hyper` functions that should be implemented in this PR/branch are `IsLow` interface functions (and related functions such as `AssertIsLow`; "interface sensitivity"), as well as functions like `IsLowSlice` that abstract over the sensitivity of slices ("slice sensitivity").

Due to [Gobra issue #955](https://github.com/viperproject/gobra/issues/955), we can't yet use `fix-846` (Gobra branch) to implement `IsLow` interface functions. (Many `TODO` comments mentioning `Once Gobra issue #846 is resolved` are now actually dependent on issue 955.)

---

### Current status

- [x] (`private/topology/underlay`) 
- [x] `private/topology`
- `pkg/addr`
  - [ ] Slice sensitivity
    - [ ] We want to introduce a specialized `IsLowSlice` function for `HostIPv4`. However, this is not possible yet, due to [Gobra issue #963](https://github.com/viperproject/gobra/issues/963). Otherwise, this is done 
  - [ ] Interface sensitivity
- `private/underlay/conn`
  - [ ] Slice sensitivity
    - [ ] We want to introduce `IsLowIP`, a specialized `IsLowSlice` function, for `UDPAddr`. However, this is not possible yet, due to [Gobra issue #963](https://github.com/viperproject/gobra/issues/963). Otherwise, this is done 
  - [ ] Interface sensitivity 
    - [ ] `UDPAddr` (can't express lowness of `IP`, see above)
    - [ ] `Conn` interface (mark `hyper`, implement `IsLow` functions)
    - Otherwise done (including `Config`, `UDPConn`)
- [x] `pkg/slayers/path/empty`
- [x] `pkg/slayers/path`
- [ ] `pkg/slayers/path/onehop`
  - [ ] Interface sensitivity
- [ ] `pkg/slayers/path/epic`
  - [ ] Interface sensitivity

---

Suggestion: `IsLow` functions that are already accompanied by a `RevealIsLow` and/or `AssertIsLow` function could be made `opaque`.